### PR TITLE
Compatibility with jasmine-node

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,10 +11,10 @@
         }
     ],
     "dependencies": {
-        "javascript.util": "0.10.0"
+        "javascript.util": "~0.10.0"
     },
     "devDependencies": {
-        "jasmine-node": "1.0.21"
+        "jasmine-node": "~1.3.0"
     },
     "directories": {
         "lib": "./src",
@@ -25,5 +25,8 @@
     "repository": {
         "type": "git",
         "url": "git://github.com/bjornharrtell/jsts.git"
+    },
+    "scripts": {
+        "test": "node_modules/.bin/jasmine-node --matchall test/spec/"
     }
 }

--- a/test/spec/spec_helper.js
+++ b/test/spec/spec_helper.js
@@ -1,0 +1,3 @@
+// Check if runing with jasmine-node and if so require dependencies into global.
+if (typeof jsts === 'undefined' && typeof require !== 'undefined')
+  global.jsts = require('../..');


### PR DESCRIPTION
Added spec helper to require jsts for running with jasmine-node and added npm test command.

Now all you need to run tests is `npm install && npm test`.
