### PR TITLE
Added bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,28 @@
+{
+    "name": "jsts",
+    "version": "0.15.0",
+    "main": [
+        "lib/javascript.util.js",
+        "lib/jsts.js"
+    ],
+    "license": "LGPL",
+    "ignore": [
+        "authors.txt",
+        "bower.json",
+        "build/*",
+        "ChangeLog",
+        "examples/*",
+        "index.js",
+        "license-notice.txt",
+        "license.txt",
+        "package.json",
+        "README.md",
+        "src/*",
+        "test/*",
+        "testxml/*",
+        "tools",
+        "validationsuite/*",
+        ".settings/*",
+        ".git/*"
+    ]
+}


### PR DESCRIPTION
This pull request enables `jsts` to be used with bower.  I haven't registered this with the bower repository yet, but it should make it easy to do.