### PR TITLE
lock javascript.util at 0.12.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
         }
     ],
     "dependencies": {
-        "javascript.util": "~0.12.5"
+        "javascript.util": "0.12.5"
     },
     "devDependencies": {
         "mocha": "~2.0.1",


### PR DESCRIPTION
@bjornharrtell we can lock the javascript.util lib at 0.12.5 to prevent libraries from breaking for now. There are several dozen live libraries out there depending on this, so anything you might be able to do would be greatly appreciated.