### PR TITLE
Fix default parameter interpretation for 'direction'

### DIFF
--- a/src/jsts/geom/CoordinateList.js
+++ b/src/jsts/geom/CoordinateList.js
@@ -74,7 +74,7 @@ jsts.geom.CoordinateList.prototype.addCoordinates = function(coord, allowRepeate
     return this.insertCoordinate.apply(this, arguments);
   }
 
-  direction = direction || true;
+  direction = typeof(direction) !== 'undefined' ? direction : true;
 
   if (direction) {
     for (var i = 0; i < coord.length; i++) {

--- a/src/jsts/geom/CoordinateList.js
+++ b/src/jsts/geom/CoordinateList.js
@@ -74,7 +74,7 @@ jsts.geom.CoordinateList.prototype.addCoordinates = function(coord, allowRepeate
     return this.insertCoordinate.apply(this, arguments);
   }
 
-  direction = typeof(direction) !== 'undefined' ? direction : true;
+  direction = (direction !== undefined) ? direction : true;
 
   if (direction) {
     for (var i = 0; i < coord.length; i++) {


### PR DESCRIPTION
In the CoordinateList.addCoordinates method the 'direction' parameter is ORed with true. This is not correct because when passing a false value the resulting direction will always be true.

I use 'typeof' operator to determine if the value is defined or not.
