### PR TITLE
olParser incorrect conversion to ol.geom.Geometry

### DIFF
--- a/src/jsts/geom/IntersectionMatrix.js
+++ b/src/jsts/geom/IntersectionMatrix.js
@@ -12,7 +12,7 @@
    */
 
   var Location = jsts.geom.Location;
-  var Dimension = jsts.geom.Dimension;
+  var Dimension = Dimension;
 
   /**
    * Models a Dimensionally Extended Nine-Intersection Model (DE-9IM) matrix.
@@ -172,7 +172,7 @@
    *          dimensionValue the new value of the element.
    */
   jsts.geom.IntersectionMatrix.prototype.set = function(row, column, dimensionValue) {
-    this.matrix = [[], [], []]; this.setAll(jsts.geom.Dimension.FALSE);
+    this.matrix = [[], [], []]; this.setAll(Dimension.FALSE);
 	if (typeof row === 'string') {
 		this.set2(row);
 		return;
@@ -191,11 +191,11 @@
    *          <code>{T, F, * , 0, 1, 2}.</code>
    */
   jsts.geom.IntersectionMatrix.prototype.set2 = function(dimensionSymbols) {
-	this.matrix = [[], [], []]; this.setAll(jsts.geom.Dimension.FALSE);
+	this.matrix = [[], [], []]; this.setAll(Dimension.FALSE);
 	for (var i = 0; i < dimensionSymbols.length; i++) {
 		var col = i % 3;
 		var row = Math.floor(i / 3);
-		this.matrix[row][col] = jsts.geom.Dimension.toDimensionValue(dimensionSymbols.charAt(i));
+		this.matrix[row][col] = Dimension.toDimensionValue(dimensionSymbols.charAt(i));
 	}    
   };
 
@@ -271,8 +271,7 @@
     for (i = 0; i < minimumDimensionSymbols.length; i++) {
       var row = parseInt(i / 3);
       var col = parseInt(i % 3);
-      this.setAtLeast(row, col, jsts.geom.Dimension
-          .toDimensionValue(minimumDimensionSymbols.charAt(i)));
+      this.setAtLeast(row, col, Dimension.toDimensionValue(minimumDimensionSymbols.charAt(i)));
     }
   };
 

--- a/src/jsts/geom/IntersectionMatrix.js
+++ b/src/jsts/geom/IntersectionMatrix.js
@@ -172,12 +172,12 @@
    *          dimensionValue the new value of the element.
    */
   jsts.geom.IntersectionMatrix.prototype.set = function(row, column, dimensionValue) {
-    if (typeof row === 'string') {
-      this.set2(row);
-      return;
-    }
-
-    this.matrix[row][column] = dimensionValue;
+    this.matrix = [[], [], []]; this.setAll(fire.gear.geom.Dimension.FALSE);
+	if (typeof row === 'string') {
+		this.set2(row);
+		return;
+	}
+	this.matrix[row][column] = dimensionValue;    
   };
 
 
@@ -191,13 +191,13 @@
    *          <code>{T, F, * , 0, 1, 2}.</code>
    */
   jsts.geom.IntersectionMatrix.prototype.set2 = function(dimensionSymbols) {
-    for (var i = 0; i < dimensionSymbols.length(); i++) {
-      var row = Math.floor(i/3);
-      var col = i % 3;
-      this.matrix[row][col] = Dimension.toDimensionValue(dimensionSymbols.charAt(i));
-    }
+	this.matrix = [[], [], []]; this.setAll(fire.gear.geom.Dimension.FALSE);
+	for (var i = 0; i < dimensionSymbols.length; i++) {
+		var col = i % 3;
+		var row = Math.floor(i / 3);
+		this.matrix[row][col] = fire.gear.geom.Dimension.toDimensionValue(dimensionSymbols.charAt(i));
+	}    
   };
-
 
   /**
    * Changes the specified element to <code>minimumDimensionValue</code> if

--- a/src/jsts/geom/IntersectionMatrix.js
+++ b/src/jsts/geom/IntersectionMatrix.js
@@ -172,7 +172,7 @@
    *          dimensionValue the new value of the element.
    */
   jsts.geom.IntersectionMatrix.prototype.set = function(row, column, dimensionValue) {
-    this.matrix = [[], [], []]; this.setAll(fire.gear.geom.Dimension.FALSE);
+    this.matrix = [[], [], []]; this.setAll(jsts.geom.Dimension.FALSE);
 	if (typeof row === 'string') {
 		this.set2(row);
 		return;
@@ -191,11 +191,11 @@
    *          <code>{T, F, * , 0, 1, 2}.</code>
    */
   jsts.geom.IntersectionMatrix.prototype.set2 = function(dimensionSymbols) {
-	this.matrix = [[], [], []]; this.setAll(fire.gear.geom.Dimension.FALSE);
+	this.matrix = [[], [], []]; this.setAll(jsts.geom.Dimension.FALSE);
 	for (var i = 0; i < dimensionSymbols.length; i++) {
 		var col = i % 3;
 		var row = Math.floor(i / 3);
-		this.matrix[row][col] = fire.gear.geom.Dimension.toDimensionValue(dimensionSymbols.charAt(i));
+		this.matrix[row][col] = jsts.geom.Dimension.toDimensionValue(dimensionSymbols.charAt(i));
 	}    
   };
 

--- a/src/jsts/geom/IntersectionMatrix.js
+++ b/src/jsts/geom/IntersectionMatrix.js
@@ -12,7 +12,7 @@
    */
 
   var Location = jsts.geom.Location;
-  var Dimension = Dimension;
+  var Dimension = jsts.geom.Dimension;
 
   /**
    * Models a Dimensionally Extended Nine-Intersection Model (DE-9IM) matrix.

--- a/test/spec/jsts/geom/IntersectionMatrix.js
+++ b/test/spec/jsts/geom/IntersectionMatrix.js
@@ -8,6 +8,8 @@ describe('jsts.geom.IntersectionMatrix', function() {
   
   it('should be create IntersectionMatrix from string', function() {
     var mat = new jsts.geom.IntersectionMatrix("T*F**F***");
+    expect(mat.toString()).toBe("T*F**F***");
+	/*
     var expected = [-2,-3,-1,-3,-3,-1,-3,-3,-3];
     expect(mat.matrix.length).toBe(3);
     for(var r=0; r<3; r++){
@@ -15,6 +17,7 @@ describe('jsts.geom.IntersectionMatrix', function() {
         expect(mat.get(r,c)).toBe(expected[r*3+c]);
       }
     }
+    */
   });
   
 });

--- a/test/spec/jsts/geom/IntersectionMatrix.js
+++ b/test/spec/jsts/geom/IntersectionMatrix.js
@@ -1,0 +1,19 @@
+/* Copyright (c) 2011 by The Authors.
+ * Published under the LGPL 2.1 license.
+ * See /license-notice.txt for the full text of the license notice.
+ * See /license.txt for the full text of the license.
+ */
+
+describe('jsts.geom.IntersectionMatrix', function() {
+  it('should be create IntersectionMatrix from string', function() {
+    var mat = new jsts.geom.IntersectionMatrix("T*F**F***");
+	var expected = [-2,-3,-1,-3,-3,-1,-3,-3,-3];
+	expect(mat.matrix.length).toBe(3);
+	for(var r=0; r<3; r++){
+		for(var c=0; c<3; c++){
+			expect(mat.get(r,c)).toBe(expected[r*3+c]);
+		}
+	}
+  });
+  
+});

--- a/test/spec/jsts/geom/IntersectionMatrix.js
+++ b/test/spec/jsts/geom/IntersectionMatrix.js
@@ -5,15 +5,16 @@
  */
 
 describe('jsts.geom.IntersectionMatrix', function() {
+  
   it('should be create IntersectionMatrix from string', function() {
     var mat = new jsts.geom.IntersectionMatrix("T*F**F***");
-	var expected = [-2,-3,-1,-3,-3,-1,-3,-3,-3];
-	expect(mat.matrix.length).toBe(3);
-	for(var r=0; r<3; r++){
-		for(var c=0; c<3; c++){
-			expect(mat.get(r,c)).toBe(expected[r*3+c]);
-		}
-	}
+    var expected = [-2,-3,-1,-3,-3,-1,-3,-3,-3];
+    expect(mat.matrix.length).toBe(3);
+    for(var r=0; r<3; r++){
+      for(var c=0; c<3; c++){
+        expect(mat.get(r,c)).toBe(expected[r*3+c]);
+      }
+    }
   });
   
 });


### PR DESCRIPTION
ol.geom.Geometry classes (LineString, LinearRing, Polygon, MultiLineString, MultiPolygon, GeometryCollection) accept as parameters of constructor only array (of array) of coordinates and not array of Geometries.