### PR TITLE
fix(PrecisionModel): Expose PrecisionModel

### DIFF
--- a/src/org/locationtech/jts/geom.js
+++ b/src/org/locationtech/jts/geom.js
@@ -14,6 +14,7 @@ import MultiLineString from './geom/MultiLineString'
 import MultiPolygon from './geom/MultiPolygon'
 import Dimension from './geom/Dimension'
 import IntersectionMatrix from './geom/IntersectionMatrix'
+import PrecisionModel from './geom/PrecisionModel'
 
 export {
   Coordinate,
@@ -31,5 +32,6 @@ export {
   MultiLineString,
   MultiPolygon,
   Dimension,
-  IntersectionMatrix
+  IntersectionMatrix,
+  PrecisionModel
 }


### PR DESCRIPTION
Expose the PrecisionModel so it can be called via jsts.geom.PrecisionModel().

Before this edit, this code:

```javascript
var jsts = require('jsts')

var pm = new jsts.geom.PrecisionModel(6)
```

Generated this error:

```
TypeError: jsts.geom.PrecisionModel is not a function
```