### PR TITLE
Allow user to set a custom reference to ol3

### DIFF
--- a/src/org/locationtech/jts/io/OL3Parser.js
+++ b/src/org/locationtech/jts/io/OL3Parser.js
@@ -9,10 +9,13 @@ function p2c (p) { return [p.x, p.y] }
 /**
  * OpenLayers 3 Geometry parser and writer
  * @param {GeometryFactory} geometryFactory
+ * @param {ol} olReference
  * @constructor
  */
-export default function OL3Parser (geometryFactory) {
+export default function OL3Parser (geometryFactory, olReference) {
   this.geometryFactory = geometryFactory || new GeometryFactory()
+
+  this.ol = olReference || (typeof ol !== 'undefined' && ol);
 }
 
 extend(OL3Parser.prototype, {
@@ -22,6 +25,7 @@ extend(OL3Parser.prototype, {
    * @memberof OL3Parser
    */
   read (geometry) {
+    var ol = this.ol;
     if (geometry instanceof ol.geom.Point) {
       return this.convertFromPoint(geometry)
     } else if (geometry instanceof ol.geom.LineString) {
@@ -128,17 +132,17 @@ extend(OL3Parser.prototype, {
   },
 
   convertToPoint (coordinate) {
-    return new ol.geom.Point([coordinate.x, coordinate.y])
+    return new this.ol.geom.Point([coordinate.x, coordinate.y])
   },
 
   convertToLineString (lineString) {
     var points = lineString.points.coordinates.map(p2c)
-    return new ol.geom.LineString(points)
+    return new this.ol.geom.LineString(points)
   },
 
   convertToLinearRing (linearRing) {
     var points = linearRing.points.coordinates.map(p2c)
-    return new ol.geom.LinearRing(points)
+    return new this.ol.geom.LinearRing(points)
   },
 
   convertToPolygon (polygon) {
@@ -146,11 +150,11 @@ extend(OL3Parser.prototype, {
     for (let i = 0; i < polygon.holes.length; i++) {
       rings.push(polygon.holes[i].points.coordinates.map(p2c))
     }
-    return new ol.geom.Polygon(rings)
+    return new this.ol.geom.Polygon(rings)
   },
 
   convertToMultiPoint (multiPoint) {
-    return new ol.geom.MultiPoint(multiPoint.getCoordinates().map(p2c))
+    return new this.ol.geom.MultiPoint(multiPoint.getCoordinates().map(p2c))
   },
 
   convertToMultiLineString (multiLineString) {
@@ -158,7 +162,7 @@ extend(OL3Parser.prototype, {
     for (let i = 0; i < multiLineString.geometries.length; i++) {
       lineStrings.push(this.convertToLineString(multiLineString.geometries[i]).getCoordinates())
     }
-    return new ol.geom.MultiLineString(lineStrings)
+    return new this.ol.geom.MultiLineString(lineStrings)
   },
 
   convertToMultiPolygon (multiPolygon) {
@@ -166,7 +170,7 @@ extend(OL3Parser.prototype, {
     for (let i = 0; i < multiPolygon.geometries.length; i++) {
       polygons.push(this.convertToPolygon(multiPolygon.geometries[i]).getCoordinates())
     }
-    return new ol.geom.MultiPolygon(polygons)
+    return new this.ol.geom.MultiPolygon(polygons)
   },
 
   convertToCollection (geometryCollection) {
@@ -175,6 +179,6 @@ extend(OL3Parser.prototype, {
       var geometry = geometryCollection.geometries[i]
       geometries.push(this.write(geometry))
     }
-    return new ol.geom.GeometryCollection(geometries)
+    return new this.ol.geom.GeometryCollection(geometries)
   }
 })


### PR DESCRIPTION
Second parameter for `OL3Parser` constructor is `olReference`. If not defined, will look for global `ol` reference
