### PR TITLE
Fix rollup for ES6

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,10 +25,10 @@
     "mocha": "3.2.0",
     "mocha-lcov-reporter": "1.2.0",
     "nyc": "10.0.0",
-    "rollup": "^0.41.4",
+    "rollup": "0.41.4",
     "rollup-plugin-babel": "2.7.1",
-    "rollup-plugin-commonjs": "^7.0.0",
-    "rollup-plugin-node-resolve": "^2.0.0",
+    "rollup-plugin-commonjs": "7.0.0",
+    "rollup-plugin-node-resolve": "2.0.0",
     "rollup-plugin-replace": "1.1.1",
     "uglify-js": "2.7.5"
   },

--- a/package.json
+++ b/package.json
@@ -25,8 +25,10 @@
     "mocha": "3.2.0",
     "mocha-lcov-reporter": "1.2.0",
     "nyc": "10.0.0",
-    "rollup": "0.39.0",
+    "rollup": "^0.41.4",
     "rollup-plugin-babel": "2.7.1",
+    "rollup-plugin-commonjs": "^7.0.0",
+    "rollup-plugin-node-resolve": "^2.0.0",
     "rollup-plugin-replace": "1.1.1",
     "uglify-js": "2.7.5"
   },

--- a/rollup.config.es6.js
+++ b/rollup.config.es6.js
@@ -6,6 +6,7 @@ import commonjs from 'rollup-plugin-commonjs'
 
 export default {
   entry: 'src/jsts.js',
+  format: 'es',
   exports: 'named',
   plugins: [
     replace({


### PR DESCRIPTION
Building the ES6 version requires installing 2 additional rollup plugins. This PR adds them as dev dependencies.

I've also taken the opportunity to update the rollup dependency itself. This introduced an additional warning when building, which I've fixed as well.