### PR TITLE
use "browser" to point webpack to pre-bundled dist

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "rollup-plugin-replace": "2.0.0",
     "uglify-js": "3.4.3"
   },
+  "browser": "dist/jsts.js",
   "main": "dist/jsts.min.js",
   "module": "index.js",
   "engines": {


### PR DESCRIPTION
I'm wondering if this change will help.

The issue is webpack + babel loads `require('jsts')` by pulling the empty `index.js` file.  I believe webpack give priority to the `browser` field and according to the lined docs I found, seems to accurately describe what the "dist/jsts.js" file represents in the bundle.

[package.json fields expalined #browser](https://github.com/stereobooster/package.json#browser)