### PR TITLE
Change babel config setup

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,9 +1,0 @@
-{
-  "presets": [
-    ["@babel/env", {
-      "targets": {
-        "node": ["8"]
-      }
-    }]
-  ]
-}

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,9 @@
+module.exports = {
+  presets: [
+    ["@babel/env", {
+      targets: {
+        node: ["8"]
+      }
+    }]
+  ]
+};


### PR DESCRIPTION
This change is to support the updated babel config setup to support parsing the config in dependencies.

Currently if I try to use `jsts` with `babel-7`I'll get errors if I try to import anything in the `org` or `java` directories and use them in jest unit tests as they use es6 imports/exports (it seems to work with older versions of babel). This is because of this change here https://github.com/facebook/jest/issues/6053#issuecomment-383632515. Here is a big thread on the topic https://github.com/facebook/jest/issues/6229.

The simple fix is to just swap `.babelrc` to `babel.config.js` as in this MR. I've verified this works for the project I'm working on with a mirror of `jsts`.