### PR TITLE
Add CoordinateSequenceFilter to geom.js

### DIFF
--- a/src/org/locationtech/jts/geom.js
+++ b/src/org/locationtech/jts/geom.js
@@ -1,5 +1,6 @@
 import Coordinate from './geom/Coordinate'
 import CoordinateList from './geom/CoordinateList'
+import CoordinateSequenceFilter from './geom/CoordinateSequenceFilter'
 import Envelope from './geom/Envelope'
 import LineSegment from './geom/LineSegment'
 import GeometryFactory from './geom/GeometryFactory'
@@ -22,6 +23,7 @@ import * as util from './geom/util'
 export {
   Coordinate,
   CoordinateList,
+  CoordinateSequenceFilter,
   Envelope,
   LineSegment,
   GeometryFactory,


### PR DESCRIPTION
I'm working on making [`geo`](https://github.com/Factual/geo) cross-compatible with Clojurescript in addition to Clojure, which means [integrating JSTS](https://github.com/Factual/geo/issues/69) alongside JTS, and ran into the same issue as #382.

`geo` performs all of its reprojection/transformation by [implementing](https://github.com/Factual/geo/blob/2e7be133f9d45d8f5ba20b538c8379cc745e5eec/src/geo/crs.clj#L139-L149) `CoordinateSequenceFilter` in JTS, and JTS [Javadocs seem to suggest](https://locationtech.github.io/jts/javadoc/org/locationtech/jts/geom/CoordinateSequenceFilter.html) that this is the preferred method for doing that kind of transformation.

By creating a function that that implements the five methods of `CoordinateSequenceFilter` (and correctly returns the class to be able to satisfy `hasInterface`, assuming it's exportable from `geom.js`), transformations of all geometries seem to be working correctly using the same process here as in JTS.

@bjornharrtell