### PR TITLE
Exceptions extend Error

### DIFF
--- a/src/java/lang/Exception.js
+++ b/src/java/lang/Exception.js
@@ -1,6 +1,7 @@
-export default class Exception {
+export default class Exception extends Error {
   constructor(message) {
-    this.message = message
+    super(message)
+    this.name = this.constructor.name
   }
   toString() {
     return this.message

--- a/test/manual/issues/258.js
+++ b/test/manual/issues/258.js
@@ -2,6 +2,7 @@ import expect from 'expect.js'
 
 import Coordinate from 'org/locationtech/jts/geom/Coordinate'
 import GeometryFactory from 'org/locationtech/jts/geom/GeometryFactory'
+import RuntimeException from 'java/lang/RuntimeException'
 import TopologyException from 'org/locationtech/jts/geom/TopologyException'
 import OverlayOp from 'org/locationtech/jts/operation/overlay/OverlayOp'
 
@@ -20,8 +21,10 @@ describe('GeometryComponentFilter is not defined on polygon intersection (#258)'
     const polygon1 = factory.createPolygon(factory.createLinearRing(coordinates))
     const polygon2 = factory.createPolygon(factory.createLinearRing(coordinates))
 
-    expect(() => OverlayOp.intersection(polygon1, polygon2)).to.throwError(e => 
+    expect(() => OverlayOp.intersection(polygon1, polygon2)).to.throwError(e => {
       expect(e).to.be.a(TopologyException)
-    )
+      expect(e).to.be.a(RuntimeException)
+      expect(e).to.be.a(Error)
+    })
   })
 })


### PR DESCRIPTION
I'm currently using jsts 2.2.2. There "java" Exceptions extend js Error:

https://github.com/bjornharrtell/jsts/blob/2.2.2/src/org/locationtech/jts/geom/TopologyException.js
https://github.com/bjornharrtell/jsts/blob/2.2.2/src/java/lang/RuntimeException.js

This was changed in 2ac1660137ee69ee965f49557fadbe578f720852 , so that "java" Exceptions no longer extended js Error. (Why?)

https://github.com/bjornharrtell/jsts/blob/2.5.0/src/org/locationtech/jts/geom/TopologyException.js
https://github.com/bjornharrtell/jsts/blob/2.5.0/src/java/lang/RuntimeException.js
https://github.com/bjornharrtell/jsts/blob/2.5.0/src/java/lang/Exception.js

This pr adds back extending js Error. (Based on this: https://javascript.info/custom-errors)

Not that I want to catch jsts Exceptions outside jsts. It's just when they extend Error, they behave better, more js error-like: better error message, stacktrace, instanceof Error, etc.