### PR TITLE
add missing file extensions

### DIFF
--- a/src/org/locationtech/jts/operation/overlay/snap.js
+++ b/src/org/locationtech/jts/operation/overlay/snap.js
@@ -1,5 +1,5 @@
-import GeometrySnapper from './snap/GeometrySnapper'
-import LineStringSnapper from './snap/LineStringSnapper'
+import GeometrySnapper from './snap/GeometrySnapper.js'
+import LineStringSnapper from './snap/LineStringSnapper.js'
 
 export {
   GeometrySnapper,

--- a/src/org/locationtech/jts/triangulate/quadedge.js
+++ b/src/org/locationtech/jts/triangulate/quadedge.js
@@ -1,4 +1,4 @@
-import Vertex from './quadedge/Vertex'
+import Vertex from './quadedge/Vertex.js'
 
 export {
   Vertex


### PR DESCRIPTION
This PR adds file extensions to the imports in a couple of files that were missed when migrating to modules. Currently, importing the files throws an error, e.g.
```js
import { GeometrySnapper } from 'jsts/org/locationtech/jts/operation/overlay/snap.js';
``` 