### PR TITLE
added return in Geometry.toString method

### DIFF
--- a/src/org/locationtech/jts/monkey.js
+++ b/src/org/locationtech/jts/monkey.js
@@ -124,7 +124,7 @@ Geometry.prototype.toText = function() {
   return writer.write(this)
 }
 Geometry.prototype.toString = function() {
-  this.toText()
+  return this.toText()
 }
 Geometry.prototype.contains = function(g) {
   return RelateOp.contains(this, g)


### PR DESCRIPTION
Thank you for maintaining this package! I noticed a missing return in the Geometry.toString method, so added it in.